### PR TITLE
Allowing ability to specify url to connect to from the client.

### DIFF
--- a/include/eventsocketcpp/RedBackConnection.h
+++ b/include/eventsocketcpp/RedBackConnection.h
@@ -79,12 +79,15 @@ namespace RedBack {
             void SetID(uint32_t _id) { id = _id; }
 
             // Connect to a server given the hostname and the port.
-            void connectToServer(boost::asio::ip::tcp::resolver::results_type& endpoints, std::function<void(void)> clientOnConnect){
+            void connectToServer(boost::asio::ip::tcp::resolver::results_type& endpoints, std::string urlPath, std::function<void(void)> clientOnConnect){
                 
                 // Does not make sense for a server to connect to another 
                 if (ownerType == owner::server){
                     return;
                 }
+
+                // To connect to a specific url path
+                _urlPath = urlPath;
 
                 // Set the timeout for the operation
                 beast::get_lowest_layer(ws).expires_after(std::chrono::seconds(30));
@@ -194,7 +197,7 @@ namespace RedBack {
                 if (ownerType == owner::server)
                     return;
                     
-                ws.async_handshake(hostname, "/",
+                ws.async_handshake(hostname, _urlPath,
                 [this, clientOnConnect](std::error_code ec){
                     
                     if (!ec){
@@ -356,5 +359,8 @@ namespace RedBack {
         private:
             // buffer to temporarily read into
             beast::flat_buffer _buffer;
+
+            // The subprotocol you want to connect to.
+            std::string _urlPath{"/"};
     };
 } // RedBack

--- a/include/eventsocketcpp/client/EventClientInterface.h
+++ b/include/eventsocketcpp/client/EventClientInterface.h
@@ -26,9 +26,16 @@ namespace RedBack
                 disconnect();
             }
 
-            // Connect to a server given the host and port
-            // Returns true if the operation is successful
-            bool connect(std::string host, uint16_t port)
+            /**
+             * Connect to an eventsocket server
+             *
+             * @param host: The hostname or IP
+             * @param port: The port number the server is listening on
+             * @param urlPath: The url path that accepts websocket connections
+             *
+             * @return: true if the operation succeeded, false otherwise.
+             * */
+            bool connect(std::string host, uint16_t port, std::string urlPath = "/")
             {
                 try 
                 {
@@ -38,13 +45,13 @@ namespace RedBack
 
                     // Resolve and connect
                     resolver.async_resolve(host, std::to_string(port),
-                    [this](boost::system::error_code ec, boost::asio::ip::tcp::resolver::results_type endpoints){
+                    [=](boost::system::error_code ec, boost::asio::ip::tcp::resolver::results_type endpoints){
 
                         // Create the connection
                         connection = std::make_shared<Connection<T>>(Connection<T>::owner::client, asioContext, qMessagesIn);
 
                         // Connect to the endpoint
-                        connection->connectToServer(endpoints, [this](){ OnConnect(); });
+                        connection->connectToServer(endpoints, urlPath, [this](){ OnConnect(); });
 
                     });
 

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -16,7 +16,6 @@ FetchContent_GetProperties(protobuf)
 if (NOT protobuf_POPULATED)
 	option(protobuf_BUILD_TESTS OFF)
 	FetchContent_Populate(protobuf)
-	#FetchContent_MakeAvailable(protobuf)
 	add_subdirectory(${protobuf_SOURCE_DIR}/cmake ${protobuf_BINARY_DIR})
 endif()
 


### PR DESCRIPTION
Ability to specify the url (or subprotocl) to connect to from the client. For example if the server is listening on 
```
https://0.0.0.0/api/v1/stream
```
to accept connections, clients can specify '/api/v1/stream' in their connection request.
